### PR TITLE
ajustando texto quebrando na listagem de membros

### DIFF
--- a/app/src/components/PersonLabel/index.tsx
+++ b/app/src/components/PersonLabel/index.tsx
@@ -12,7 +12,7 @@ export function PersonLabelComponent({
   return (
     <S.Box>
       <S.ContainerPerson>
-        <S.TextName>{nome}</S.TextName>
+        <S.TextName numberOfLines={1}>{nome}</S.TextName>
         <S.BoxStatus status={status}>
           <S.TextStatus>{status}</S.TextStatus>
         </S.BoxStatus>

--- a/app/src/components/PersonLabel/styles.ts
+++ b/app/src/components/PersonLabel/styles.ts
@@ -46,6 +46,7 @@ export const TextName = styled.Text`
   font-size: 14;
   line-height: 16;
   color: #666666;
+  max-width: 240px;
 `;
 
 export const BoxStatus = styled.View<props>`


### PR DESCRIPTION
Na listagem quando o nome é muito grande ele joga os ícones de editar e excluir para o lado.